### PR TITLE
added initial src for the redo/undo images

### DIFF
--- a/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
+++ b/djangocms_history/templates/djangocms_history/toolbar/ajax_button.html
@@ -2,7 +2,7 @@
     <span>
         <img
             aria-hidden="true" style="vertical-align: text-bottom" class="{{ classes }}"
-            width="16" height="16" src="{{ icon }}" alt="{{ name }}"
+            width="16" height="16" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAM9JREFUWEftlksOwCAIRPW0nsnTtnFBYqwwg/GTJnYrn+dAwRgOf/Fw/nABXArknB+mZCklOu7HsE4igdjELRwDYgIwt0U2CGI5QAG0ILYAWBBDANqNUK/0/NwAqKblthrIFABUU2lKFsKtwG8AtFK0ZaAnFvrfe+e9MlyAq8A2BYbnQNvNEoiZgLXvFIA2CAvBJi/A6hywFsvSZYRm+chAcq1jpo5eCNeDRGtCb1KxR31D7QL00NDgUHKzCdnl0rNjEosfpcCo/IzfBTiuwAuFfoQhCFHtvgAAAABJRU5ErkJggg==" alt="{{ name }}"
             title="{{ name }}">
         <span class="cms-hidden" style="display: none;">{{ name }}</span>
     </span>


### PR DESCRIPTION
## Description

The img tags in template needs a src value to start with. Once it is loaded the css with base64 images kicks in.


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
