### PR TITLE
fix: Store session cookie hash to avoid different lengths for different backends

### DIFF
--- a/djangocms_history/helpers.py
+++ b/djangocms_history/helpers.py
@@ -16,7 +16,7 @@ from django.utils import timezone
 from cms.models import CMSPlugin, Placeholder
 from cms.utils import get_language_from_request
 
-from .utils import get_plugin_fields, get_plugin_model
+from .utils import get_plugin_fields, get_plugin_model, get_session_key_hash
 
 if TYPE_CHECKING:
     from .models import PlaceholderOperation
@@ -175,7 +175,7 @@ def get_operations_from_request(
         origin=origin,
         language=language,
         user=request.user,
-        user_session_key=request.session.session_key,
+        user_session_key=get_session_key_hash(request.session.session_key),
         date_created__gt=date,
         is_archived=False,
     )

--- a/djangocms_history/migrations/0004_hash_session_keys.py
+++ b/djangocms_history/migrations/0004_hash_session_keys.py
@@ -3,10 +3,16 @@ import hashlib
 from django.db import migrations, models
 
 
+HASH_PREFIX = "sha256$"
+
+
 def hash_session_keys(apps, schema_editor):
     PlaceholderOperation = apps.get_model("djangocms_history", "PlaceholderOperation")
     for operation in PlaceholderOperation.objects.only("pk", "user_session_key").iterator():
-        operation.user_session_key = hashlib.sha256(operation.user_session_key.encode()).hexdigest()
+        if operation.user_session_key.startswith(HASH_PREFIX):
+            continue
+        digest = hashlib.sha256(operation.user_session_key.encode()).hexdigest()
+        operation.user_session_key = HASH_PREFIX + digest
         operation.save(update_fields=["user_session_key"])
 
 
@@ -21,6 +27,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="placeholderoperation",
             name="user_session_key",
-            field=models.CharField(db_index=True, max_length=64),
+            field=models.CharField(db_index=True, max_length=72),
         ),
     ]

--- a/djangocms_history/migrations/0004_hash_session_keys.py
+++ b/djangocms_history/migrations/0004_hash_session_keys.py
@@ -1,0 +1,26 @@
+import hashlib
+
+from django.db import migrations, models
+
+
+def hash_session_keys(apps, schema_editor):
+    PlaceholderOperation = apps.get_model("djangocms_history", "PlaceholderOperation")
+    for operation in PlaceholderOperation.objects.only("pk", "user_session_key").iterator():
+        operation.user_session_key = hashlib.sha256(operation.user_session_key.encode()).hexdigest()
+        operation.save(update_fields=["user_session_key"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("djangocms_history", "0003_delete_cms3_history"),
+    ]
+
+    operations = [
+        migrations.RunPython(hash_session_keys, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="placeholderoperation",
+            name="user_session_key",
+            field=models.CharField(db_index=True, max_length=64),
+        ),
+    ]

--- a/djangocms_history/models.py
+++ b/djangocms_history/models.py
@@ -325,7 +325,7 @@ class PlaceholderOperation(models.Model):
         on_delete=models.CASCADE,
         verbose_name="user",
     )
-    user_session_key = models.CharField(max_length=64, db_index=True)
+    user_session_key = models.CharField(max_length=72, db_index=True)
     date_created = models.DateTimeField(
         db_index=True,
         auto_now_add=True,

--- a/djangocms_history/models.py
+++ b/djangocms_history/models.py
@@ -22,7 +22,7 @@ from cms.signals import post_placeholder_operation, pre_placeholder_operation
 from . import action_handlers, actions, operation_handlers, signals
 from .datastructures import ArchivedPlugin
 from .helpers import get_operation_origin
-from .utils import plugin_has_m2m
+from .utils import get_session_key_hash, plugin_has_m2m
 
 dump_json = functools.partial(json.dumps, cls=DjangoJSONEncoder)
 
@@ -161,7 +161,7 @@ def archive_old_operations(
         PlaceholderOperation
         .objects
         .filter(user=request.user, site=site)
-        .exclude(user_session_key=request.session.session_key)
+        .exclude(user_session_key=get_session_key_hash(request.session.session_key))
     )
     archive_or_delete_operations(p_operations)
 
@@ -194,7 +194,7 @@ def clear_operation_history(request: HttpRequest, site: Site, origin: str) -> No
             site=site,
             origin=origin,
             user=request.user,
-            user_session_key=request.session.session_key,
+            user_session_key=get_session_key_hash(request.session.session_key),
         )
     )
 
@@ -234,7 +234,7 @@ def create_placeholder_operation(sender: Any, **kwargs: Any) -> None:
         origin=origin,
         language=language,
         user=request.user,
-        user_session_key=request.session.session_key,
+        user_session_key=get_session_key_hash(request.session.session_key),
         site=site,
     )
     handler(operation, **kwargs)
@@ -269,7 +269,7 @@ def update_placeholder_operation(sender: Any, **kwargs: Any) -> None:
     p_operations = PlaceholderOperation.objects.filter(
         site=site,
         user=request.user,
-        user_session_key=request.session.session_key
+        user_session_key=get_session_key_hash(request.session.session_key)
     )
 
     operation = p_operations.get(token=kwargs['token'])
@@ -325,8 +325,7 @@ class PlaceholderOperation(models.Model):
         on_delete=models.CASCADE,
         verbose_name="user",
     )
-    # Django uses 40 character session keys but other backends might use longer..
-    user_session_key = models.CharField(max_length=120, db_index=True)
+    user_session_key = models.CharField(max_length=64, db_index=True)
     date_created = models.DateTimeField(
         db_index=True,
         auto_now_add=True,

--- a/djangocms_history/utils.py
+++ b/djangocms_history/utils.py
@@ -7,10 +7,14 @@ from cms.models import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
+SESSION_KEY_HASH_PREFIX = "sha256$"
 
-def get_session_key_hash(session_key: str) -> str:
-    """Return a fixed-length identifier for a session key."""
-    return hashlib.sha256(session_key.encode()).hexdigest()
+
+def get_session_key_hash(session_key: str | None) -> str:
+    """Return a versioned, fixed-length identifier for a session key."""
+    if session_key is None:
+        raise ValueError("A session key is required to record history")
+    return SESSION_KEY_HASH_PREFIX + hashlib.sha256(session_key.encode()).hexdigest()
 
 
 @lru_cache()

--- a/djangocms_history/utils.py
+++ b/djangocms_history/utils.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import hashlib
 from functools import lru_cache
 
 from cms.models import CMSPlugin
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
+
+
+def get_session_key_hash(session_key: str) -> str:
+    """Return a fixed-length identifier for a session key."""
+    return hashlib.sha256(session_key.encode()).hexdigest()
 
 
 @lru_cache()

--- a/tests/test_operation_recording.py
+++ b/tests/test_operation_recording.py
@@ -12,6 +12,10 @@ from .base import HistoryTestCase
 
 class OperationRecordingTestCase(HistoryTestCase):
 
+    def test_session_key_hash_requires_session_key(self):
+        with self.assertRaisesMessage(ValueError, 'A session key is required'):
+            get_session_key_hash(None)
+
     def test_add_plugin_records_operation(self):
         with self.login_user_context(self.superuser):
             plugin = self.add_plugin_via_endpoint()
@@ -57,7 +61,8 @@ class OperationRecordingTestCase(HistoryTestCase):
 
             operation = self.latest_operation()
             self.assertEqual(operation.user_session_key, get_session_key_hash(session.session_key))
-            self.assertEqual(len(operation.user_session_key), 64)
+            self.assertTrue(operation.user_session_key.startswith('sha256$'))
+            self.assertEqual(len(operation.user_session_key), 71)
 
     def test_add_nested_plugin_records_parent(self):
         parent = self.add_plugin()

--- a/tests/test_operation_recording.py
+++ b/tests/test_operation_recording.py
@@ -1,9 +1,11 @@
+from django.conf import settings
 from django.test import override_settings
 
 from cms import operations
 
 from djangocms_history import actions
 from djangocms_history.models import PlaceholderOperation
+from djangocms_history.utils import get_session_key_hash
 
 from .base import HistoryTestCase
 
@@ -41,6 +43,21 @@ class OperationRecordingTestCase(HistoryTestCase):
         self.assertEqual(archived.position, 1)
         self.assertEqual(archived.plugin_type, 'LinkPlugin')
         self.assertEqual(archived.data['name'], 'A Link')
+
+    @override_settings(SESSION_ENGINE='django.contrib.sessions.backends.signed_cookies')
+    def test_add_plugin_with_long_signed_cookie_session_key(self):
+        with self.login_user_context(self.superuser):
+            session = self.client.session
+            session['long_value'] = ''.join(chr(33 + index % 90) for index in range(300))
+            session.save()
+            self.client.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
+            self.assertGreater(len(session.session_key), 120)
+
+            self.add_plugin_via_endpoint()
+
+            operation = self.latest_operation()
+            self.assertEqual(operation.user_session_key, get_session_key_hash(session.session_key))
+            self.assertEqual(len(operation.user_session_key), 64)
 
     def test_add_nested_plugin_records_parent(self):
         parent = self.add_plugin()


### PR DESCRIPTION
## Summary by Sourcery

Hash user session keys before storing operations to ensure a fixed-length identifier across session backends and migrate existing data accordingly.

Bug Fixes:
- Prevent issues caused by varying session key lengths from different session backends by storing a hashed session identifier.

Enhancements:
- Introduce a helper utility to generate a fixed-length hash for session keys and use it throughout operation recording logic.
- Update the PlaceholderOperation model to store a 64-character session key hash instead of the raw session key.

Tests:
- Add a test covering operation recording when using long signed-cookie-based session keys to validate hashing behavior.

Chores:
- Add a data migration to backfill and convert existing stored session keys to their hashed representation.


## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #39
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.